### PR TITLE
Update test to pass

### DIFF
--- a/test/useAsyncSetState.test.tsx
+++ b/test/useAsyncSetState.test.tsx
@@ -7,26 +7,24 @@ type TestState = {
 };
 
 test('should increment counter', async () => {
-  const useAsyncSetStateHook = renderHook(() =>
+  const { result } = renderHook(() =>
     useAsyncSetState<TestState>({ label: 'hey', counter: 0 })
   );
 
-  const getState = () => useAsyncSetStateHook.result.current[0];
-  const setStateAsync = useAsyncSetStateHook.result.current[1];
-
+  const getState = () => result.current[0];
+  const setStateAsync = result.current[1];
 
   const assertCounter = (expectedValue: number) =>
     expect(getState().counter).toBe(expectedValue);
 
   const incrementAsync = async () => {
-    const promise = await act(() =>
-      setStateAsync({
+    let promise: any;
+    act(() => {
+      promise = setStateAsync({
         ...getState(),
         counter: getState().counter + 1,
-      }) as any
-    );
-    await act(() => useAsyncSetStateHook.waitForNextUpdate() as any);
-    await act(() => useAsyncSetStateHook.rerender() as any);
+      });
+    });
     await promise;
   };
 
@@ -37,5 +35,4 @@ test('should increment counter', async () => {
   assertCounter(2);
   await incrementAsync();
   assertCounter(3);
-
 });


### PR DESCRIPTION
Because the `setState` calls are actually synchronous, there are no updates to wait for causing the tests to timeout.  Similarly, `setState` triggers the render to occur, so there is no need to call `rerender` yourself.

Note: if you are happy to use an alpha version of react (version `16.9.0-alpha.0`), this test can become:

```js
test('should increment counter', async () => {
  const { result } = renderHook(() =>
    useAsyncSetState<TestState>({ label: 'hey', counter: 0 })
  );

  const getState = () => result.current[0];
  const setStateAsync = result.current[1];

  const assertCounter = (expectedValue: number) =>
    expect(getState().counter).toBe(expectedValue);

  const incrementAsync = async () => {
    await act(() => 
      setStateAsync({
        ...getState(),
        counter: getState().counter + 1,
      }) as any
    );
  };

  assertCounter(0);
  await incrementAsync();
  assertCounter(1);
  await incrementAsync();
  assertCounter(2);
  await incrementAsync();
  assertCounter(3);
});
```

(I'm happy to update this PR with that if you want)