### PR TITLE
added union to support lazy-initial-state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,9 @@ export const useAsyncSetStateFunction = <S>(
   );
 };
 
-export const useAsyncSetState = <S>(initialState: S): [S, AsyncSetState<S>] => {
+export const useAsyncSetState = <S>(
+  initialState: S | (() => S)
+): [S, AsyncSetState<S>] => {
   const [state, setState] = useState(initialState);
   const setStateAsync = useAsyncSetStateFunction(state, setState);
   return [state, setStateAsync];


### PR DESCRIPTION
Added union that includes function in useAsyncSetState parameter, because useState allows function as initial state, which will only be executed on the initial render: [React docs on Lazy Initial State](https://reactjs.org/docs/hooks-reference.html#lazy-initial-state).

Based on React useState type
```
/**
 * Returns a stateful value, and a function to update it.
 *
 * @version 16.8.0
 * @see https://reactjs.org/docs/hooks-reference.html#usestate
 */
function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
```